### PR TITLE
Sgibson/fix note ext

### DIFF
--- a/.make/setup-zsh-completion.sh
+++ b/.make/setup-zsh-completion.sh
@@ -1,27 +1,10 @@
 #!/bin/sh -
 repo_completion_dir=$(git rev-parse --show-toplevel)/completion/zsh
-home_completion_dir=~/.zsh_completions
 
-
-# generate a zsh_completions directory
-if [ ! -d $home_completion_dir  ]; then
-    mkdir $home_completion_dir
-fi
-
-# symlink the generated completion file to zsh_completions dir
+# symlink the generated completion file to site-functions
 if [ -e $repo_completion_dir/_note ]; then
-  ln -sf $repo_completion_dir/_note $home_completion_dir/_note
+  echo Creating symlink in /usr/local/share/zsh/site-functions...
+  sudo ln -sf $repo_completion_dir/_note /usr/local/share/zsh/site-functions
 else
   echo "zsh completion file does not exist, run 'make generate/zsh-completion' to create it" >&2
 fi
-
-# source the zsh_completions dir when starting shell
-zshrc_lines=$(cat <<EOF
-# zsh command completion
-fpath=($home_completion_dir \$fpath)
-autoload -U compinit
-compinit
-EOF
-)
-
-printf "$zshrc_lines" >> ~/.zshrc

--- a/README.md
+++ b/README.md
@@ -77,17 +77,8 @@ Currently there is only support for `zsh` command completion. It will present
 options available to you and the complete the names of notes you have in your
 notes directory.
 
-To set yourself up run `make install/zsh-completion` which will:
-* create a directory called `.zsh_completions` in your home directory.
-* generate the completion file and symlink from `.zsh_completions` to it.
-* add a few lines to your `.zshrc` to add `.zsh_completion` to your `$fpath`
-  which is what zsh uses to find completion files for commands.
-
-If you have already set up custom command completion before or you have
-somewhere you like to put completion files then run `make
-generate/zsh-completion` to generate the completion file in the
-[`/completion/zsh`](/completion/zsh/) directory.  Symlink to this file from
-which ever directory you keep your completion files.
-
-Be sure to reload your shell so zsh picks up this new completions file and
-you're good to go.
+- Generate the completion file by running `make generate/zsh-completion`.
+- Run `make install/zsh-completion` to symlink to the newly created completion
+  file from `/usr/local/share/zsh/site-functions`. It uses sudo to create the
+  symlink, so you will be asked for your password.
+- Reload your shell.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ small command to help you create or edit notes.
 
 This is a small script that works in conjunction with your editor to do just
 that. It will keep all your notes in a directory of your choosing and has some
-options for simple searching. The notes will be created with the markdown
-extension unless overridden by an [environment variable](#customise)
+options for simple searching, the notes will be created with the markdown
+extension unless told otherwise, check out the [customise](#customise) section
+for more details.
 
 - [Installation](#installation)
 - [Usage](#usage)
@@ -28,10 +29,12 @@ extension unless overridden by an [environment variable](#customise)
 ## Usage
 
 ```
-note [--list|-l]
+note [--help|-h]
+     [--list|-l]
      [--search|-s <name>]
      [--text-search|-t <text...>]
      [--delete|-d <name>]
+     [--no-extension|-n <name-with-ext>]
      [--] [<name>]
 ```
 
@@ -52,6 +55,9 @@ name.
 
 `note --delete <name>` will attempt to delete that note.
 
+`note --no-extension <extension> <name>` will create a new note without adding
+an extension, this is useful if you want to provide one, i.e. `note -n file.c`
+
 `note --help` will display command usage.
 
 ## Customise
@@ -62,8 +68,8 @@ default.
 Set `NOTES_DIR` to specify where you want to keep your notes, the default is
 `$HOME/.notes`
 
-Set `NO_NOTE_EXT` to anything at all if you don't want the markdown extension
-added to your files.
+Set `NOTE_EXT` to specify which extension you would like new notes to have, the
+default is `md`.
 
 ## Command completion
 

--- a/completion/zsh/completion-template
+++ b/completion/zsh/completion-template
@@ -1,30 +1,11 @@
 #compdef note
 
-local context state state_descr line
-typeset -A opt_args
 local -a files=($(find NOTE_DIR -path NOTE_DIR/.git -prune -o -type f -printf '%P '))
 
-_arguments '--help[display command usage]' \
-           '-h[display command usage]' \
-           '--search[search for a note]' \
-           '-s[search for a note]' \
-           '--text-search[search for text in your notes]' \
-           '-t[search for text in your notes]' \
-           '--delete[delete a note]' \
-           '-d[delete a note]' \
-           '1:name:->name'
+_arguments -S -C {-h,--help}'[display command usage]'\
+           {-s,--search}'[search for a note]'\
+           {-t,--text-search}'[search for text in your notes]'\
+           {-d,--delete}'[delete a note]'\
+           {-n,--no-extension}'[no extension]'\
+             "*:name:($files)"
   
-case $state in
-  name )
-    if [ ${#words[@]} -gt 2 ]; then
-      case $words[2] in
-        --search | -s | --delete | -d)
-        compadd "$@" $files
-        ;;
-      esac
-    else
-      compadd "$@" $files
-    fi
-    ;;
-esac
-

--- a/note
+++ b/note
@@ -12,8 +12,11 @@
 #             [--search|-s <name>]
 #             [--text-search|-t <text...>]
 #             [ --delete|-d <name> ]
-#             [<name>]
+#             [--no-extension|-n <name-with-ext>]
+#             [--] [<name>]
 
+ext=${NOTE_EXT:-md}
+no_ext=
 notes_dir="${NOTES_DIR:-$HOME/.notes}"
 file=
 
@@ -106,7 +109,8 @@ usage() {
               [--search|-s <name>]
               [--text-search|-t <text...>]
               [ --delete|-d <name> ]
-              [<name>]
+              [--no-extension|-n <name-with-ext>]
+              [--] [<name>]
 "
 }
 
@@ -139,6 +143,12 @@ case "$1" in
     check_not_empty $1
     delete_file $1
     ;;
+  --no-extension | -n)
+    shift
+    no_ext=true
+    check_not_empty $1
+    file=$1
+    ;;
   --)
     shift
     find_file $1
@@ -158,11 +168,9 @@ esac
 
 # Set markdown extension unless overridden by the env var and
 # a file name has been provided
-if [ -z "$NO_NOTE_EXT" ] &&
-   [ -n "$file" ] &&
-   grep -vE '\.md$' <<< $file > /dev/null; then
-
-  file=$file.md
+if [ -n "$file" ] && [ ! "$no_ext" ] && grep -vE "\.$ext$" <<< $file > /dev/null; then
+  echo $no_ext
+  file=$file.$ext
 fi
 
 ${EDITOR:-vim} $notes_dir/$file


### PR DESCRIPTION
- Change `NO_NOTE_EXT` to `NOTE_EXT` so uses can set a global note extension to use each time a note is created, replace the environment variable with a `--no-extension` option when they want to provide one on the command line.
- Simplify completion set up by using a zsh directory