### PR TITLE
note: fix logic when setting extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ small command to help you create or edit notes.
 This is a small script that works in conjunction with your editor to do just
 that. It will keep all your notes in a directory of your choosing and has some
 options for simple searching, the notes will be created with the markdown
-extension unless told otherwise, check out the [customise](#customise) section
-for more details.
+extension unless specify one when creating your note, check out the
+[customise](#customise) section for more details to change the default
+extension.
 
 - [Installation](#installation)
 - [Usage](#usage)
@@ -34,7 +35,6 @@ note [--help|-h]
      [--search|-s <name>]
      [--text-search|-t <text...>]
      [--delete|-d <name>]
-     [--no-extension|-n <name-with-ext>]
      [--] [<name>]
 ```
 
@@ -54,9 +54,6 @@ name.
 `note --text-search <text...>` will search your notes for that text using grep.
 
 `note --delete <name>` will attempt to delete that note.
-
-`note --no-extension <name-with-ext>` will create a new note without adding
-an extension, this is useful if you want to provide one, i.e. `note -n file.c`
 
 `note --help` will display command usage.
 

--- a/note
+++ b/note
@@ -143,12 +143,6 @@ case "$1" in
     check_not_empty $1
     delete_file $1
     ;;
-  --no-extension | -n)
-    shift
-    no_ext=true
-    check_not_empty $1
-    file=$1
-    ;;
   --)
     shift
     find_file $1
@@ -166,10 +160,13 @@ case "$1" in
     ;;
 esac
 
-# Set markdown extension unless overridden by the env var and
-# a file name has been provided
-if [ -n "$file" ] && [ ! "$no_ext" ] && grep -vE "\.$ext$" <<< $file > /dev/null; then
-  echo $no_ext
+# Set extension if
+# - a file name has been provided
+# - the --no-extension option wasn't provided
+# - the file name doesn't have a . followed by anything
+if [ -n "$file" ] && [ ! "$no_ext" ] && grep -vE "\..*$" <<< $file > /dev/null; then
+  echo $ext
+
   file=$file.$ext
 fi
 


### PR DESCRIPTION
The logic was a little messy, if a note was found with any extension
other than `md` it would append either the default `md` or the user
specified `NOTE_EXT`. So, I simplified the logic to just check if there
is a period in the name and assume this is for an extension